### PR TITLE
Refactor Twitch global and channel emote support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ jspm_packages
 .node_repl_history
 # Created by .ignore support plugin (hsz.mobi)
 
+.history
 .idea/
 bin/
 build/

--- a/src/common/background/js/emoteManager.js
+++ b/src/common/background/js/emoteManager.js
@@ -42,24 +42,20 @@ function loadAllEmotes() {
         var channelIdEmotePromises = [];
 
         if (settings.twitchGlobal) {
-            promises.push(generateEmoteSet('twitchGlobal', EMOTE_SETS.twitchGlobal.getURL()).then(function() {
+            promises.push(generateTwitchEmoteSet('twitchGlobal', EMOTE_SETS.twitchGlobal.getURL()).then(function() {
                 generatedEmotes.twitchGlobal = cachedEmotes.twitchGlobal;
             }));
         }
 
         if (settings.twitchChannels && settings.twitchChannelsList.length > 0) {
-            promises.push(new Promise(function(resolve, reject) {
-                channelIdEmotePromises.push(new Promise(function(innerResolve) {
-                    for (var i = 0; i < settings.twitchChannelsList.length; ++i) {
-                        var channel = settings.twitchChannelsList[i].toLowerCase().trim();
-
-                        channelIdEmotePromises.push(fetchEmotesUsingChannelId('twitchChannels:' + channel, channel, EMOTE_SETS.twitchChannels));
-                    }
-
-                    innerResolve();
-                }));
-                
-                Promise.allSettled(channelIdEmotePromises).then(resolve);
+            promises.push(new Promise(function (resolve, reject) {
+                for (var i = 0; i < settings.twitchChannelsList.length; ++i) {
+                    var channel = settings.twitchChannelsList[i].toLowerCase().trim();
+                    promises.push(generateTwitchEmoteSet('twitchChannels:' + channel, EMOTE_SETS.twitchChannels.getURL(channel)).then(function (setName) {
+                        generatedEmotes[setName] = cachedEmotes[setName];
+                    }).catch(reject));
+                }
+                resolve();
             }));
         }
 
@@ -164,6 +160,14 @@ function generateEmoteSet(set, url) {
     });
 }
 
+function generateTwitchEmoteSet(set, url) {
+    return new Promise(function (resolve, reject) {
+        retrieveCachedEmotes(set).then(resolve).catch(function (set) {
+            fetchAndCacheEmotesFromTwitchServer(set, url).then(resolve).catch(reject);
+        });
+    });
+}
+
 function retrieveCachedEmotes(set) {
     return new Promise(function(resolve, reject) {
         storageHelper.getCacheEntry(set).then(function(cachedEntry) {
@@ -235,6 +239,67 @@ function fetchAndCacheEmotesFromServer(set, url) {
             console.error('Failed to retrieve "' + set + '" from ' + url + ' - ' + error);
 
             reject(set);
+        });
+    });
+}
+
+function fetchAndCacheEmotesFromTwitchServer(set, url) {
+    return new Promise(function (resolve, reject) {
+        twitchHelix.getBearerToken().then(function (access_token) {
+            console.log('Retrieving "' + set + '" from twitch\'s server...');
+            if (set == 'twitchGlobal') {
+                httpRequest.get(url, {
+                    method: 'GET',
+                    headers: {
+                        'Authorization': 'Bearer ' + access_token,
+                        'Client-Id': twitchHelix.getClientID()
+                    }
+                }).then(function (jsonData) {
+                    var parserModule = set.indexOf(':') !== -1 ? set.substr(0, set.indexOf(':')) : set;
+                    var emotes = {
+                        emotes: EMOTE_SETS[parserModule].parseEmotes(jsonData),
+                        date: Date.now()
+                    };
+                    console.log('Successfully retrieved "' + set + '" from twitch\'s server. Caching...');
+
+                    cachedEmotes[set] = emotes;
+
+                    storageHelper.setCacheEntry(set, emotes.emotes, emotes.date).then(function () {
+                        console.log('Cached copy of "' + set + '" successfully.');
+                    });
+                    resolve(set);
+                }).catch(function (error) {
+                    console.error('Failed to retrieve "' + set + '" from ' + url + ' - ' + error);
+                    reject(set);
+                });
+            } else {
+                twitchHelix.getChannelIdFromName(set.substr(set.indexOf(':') + 1, set.length)).then(function (channel_id) {
+                    httpRequest.get(url + channel_id, {
+                        method: 'GET',
+                        headers: {
+                            'Authorization': 'Bearer ' + access_token,
+                            'Client-Id': twitchHelix.getClientID()
+                        }
+                    }).then(function (jsonData) {
+                        var parserModule = set.indexOf(':') !== -1 ? set.substr(0, set.indexOf(':')) : set;
+                        var emotes = {
+                            emotes: EMOTE_SETS[parserModule].parseEmotes(jsonData, set.substr(set.indexOf(':') + 1, set.length)),
+                            date: Date.now()
+                        };
+                        console.log('Successfully retrieved "' + set + '" from twitch\'s server. Caching...');
+
+                        cachedEmotes[set] = emotes;
+
+                        storageHelper.setCacheEntry(set, emotes.emotes, emotes.date).then(function () {
+                            console.log('Cached copy of "' + set + '" successfully.');
+                        });
+                        resolve(set);
+                    }).catch(function (error) {
+                        console.error('Failed to retrieve "' + set + '" from ' + url + channel_id + ' - ' + error);
+                        reject(set);
+                    });
+                });
+            }
         });
     });
 }

--- a/src/common/background/js/emoteSets/twitchChannels.js
+++ b/src/common/background/js/emoteSets/twitchChannels.js
@@ -2,8 +2,7 @@ const CHANNEL_EMOTES_ENDPOINT = 'https://api.twitch.tv/helix/chat/emotes?broadca
 const BASE_EMOTE_URL = 'https://static-cdn.jtvnw.net/emoticons/v2/{EMOTE_ID}/default/light/1.0';
 
 
-function parseEmotes(json) {
-    var channelName = json.channel_name;
+function parseEmotes(json, channelName) {
     var emotes = json.data;
 
     var channelEmotes = {};

--- a/src/common/background/js/emoteSets/twitchChannels.js
+++ b/src/common/background/js/emoteSets/twitchChannels.js
@@ -1,18 +1,17 @@
-
-const CHANNEL_EMOTES_ENDPOINT = 'https://api.twitchemotes.com/api/v4/channels/{CHANNEL_ID}';
-const BASE_EMOTE_URL = 'https://static-cdn.jtvnw.net/emoticons/v1/{EMOTE_ID}/1.0';
+const CHANNEL_EMOTES_ENDPOINT = 'https://api.twitch.tv/helix/chat/emotes?broadcaster_id=';
+const BASE_EMOTE_URL = 'https://static-cdn.jtvnw.net/emoticons/v2/{EMOTE_ID}/default/light/1.0';
 
 
 function parseEmotes(json) {
     var channelName = json.channel_name;
-    var emotes = json.emotes;
+    var emotes = json.data;
 
     var channelEmotes = {};
 
     for (var i = 0; i < emotes.length; ++i) {
-        var code = emotes[i].code;
+        var name = emotes[i].name;
 
-        channelEmotes[code] = {
+        channelEmotes[name] = {
             url: BASE_EMOTE_URL.replace('{EMOTE_ID}', emotes[i].id),
             channel: channelName
         };
@@ -24,7 +23,7 @@ function parseEmotes(json) {
 
 module.exports = {
     parseEmotes: parseEmotes,
-    getURL: function(channelId) {
-        return CHANNEL_EMOTES_ENDPOINT.replace('{CHANNEL_ID}', channelId);
+    getURL: function() {
+        return CHANNEL_EMOTES_ENDPOINT;
     }
 };

--- a/src/common/background/js/emoteSets/twitchGlobal.js
+++ b/src/common/background/js/emoteSets/twitchGlobal.js
@@ -1,16 +1,16 @@
-const URL = 'https://api.twitchemotes.com/api/v4/channels/0';
-const BASE_EMOTE_URL = 'https://static-cdn.jtvnw.net/emoticons/v1/{EMOTE_ID}/1.0';
+const URL = 'https://api.twitch.tv/helix/chat/emotes/global/';
+const BASE_EMOTE_URL = 'https://static-cdn.jtvnw.net/emoticons/v2/{EMOTE_ID}/default/light/1.0';
 
 
 function parseEmotes(json) {
     var result = {};
-    var emoteList = json.emotes;
+    var emoteList = json.data;
 
     for (var i = 0; i < emoteList.length; i++) {
-        var code = emoteList[i].code;
+        var name = emoteList[i].name;
         var id = emoteList[i].id;
 
-        result[code] = {
+        result[name] = {
             url: BASE_EMOTE_URL.replace('{EMOTE_ID}', id),
             channel: ''
         };

--- a/src/common/background/js/twitchHelix.js
+++ b/src/common/background/js/twitchHelix.js
@@ -48,10 +48,17 @@ function getChannelIdFromName(channel_name) {
         
     });
 }
+
 function getClientSecret() {
     return ''; // twitch client secret
 }
 
+function getClientID() {
+    return CLIENT_ID;
+}
+
 module.exports = {
+    getClientID: getClientID,
+    getBearerToken: getBearerToken,
     getChannelIdFromName: getChannelIdFromName
 };


### PR DESCRIPTION
This PR scraps the twitchemotes API in favor of twitch's dedicated API for getting global and channel emotes. This PR also allows animated subscriber emotes to be rendered, as well as follower and bit emotes. 